### PR TITLE
型ヒントの調整とSessionラッパー追加

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -24,7 +24,10 @@ def gm_node(state: GState) -> GState:
 
 def battle_node(state: GState) -> GState:
     '''バトルノード：ダメージを与えるだけの最小処理'''
-    sess = Session.load(state["session_id"])
+    sid = state.get("session_id")
+    if not sid:
+        return {"message": "セッションID未指定", "decision": "battle", "dmg_to_player": 0}
+    sess = Session.load(sid)
     if not sess:
         return {"message": "セッションが見つからない", "decision": "battle", "dmg_to_player": 0}
 
@@ -48,7 +51,10 @@ def battle_node(state: GState) -> GState:
 
 def narrate_node(state: GState) -> GState:
     '''ナレーノード：探索・雰囲気テキストのダミー'''
-    sess = Session.load(state["session_id"])
+    sid = state.get("session_id")
+    if not sid:
+        return {"message": "セッションID未指定", "decision": "narrate"}
+    sess = Session.load(sid)
     if not sess:
         return {"message": "セッションが見つからない", "decision": "narrate"}
     line = random.choice(["森は静かだ…", "遠くでスライムの鳴き声がする。", "道端に奇妙な石碑がある。"])

--- a/models.py
+++ b/models.py
@@ -9,7 +9,7 @@ import random
 import time
 from dataclasses import dataclass, field, asdict
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 import redis
 
 
@@ -394,8 +394,8 @@ class SessionBundle:
     def redis_load(session_id: str, r: Optional[redis.Redis] = None) -> Optional["SessionBundle"]:
         '''Redisからセッション状態を読み込む（なければNone）'''
         r = r or get_redis()
-        raw = r.get(rkey("session", session_id))
-        if not raw:
+        raw = cast(Optional[str], r.get(rkey("session", session_id)))
+        if raw is None:
             return None
         d = json.loads(raw)
         bundle = SessionBundle(
@@ -507,6 +507,30 @@ class SessionBundle:
         return f"[{ts}] [SYS] {text}"
 
 
+# 旧版との互換用に、簡易なラッパークラスを用意
+class Session(SessionBundle):
+    """旧インターフェース互換のセッション管理"""
+
+    @staticmethod
+    def new(session_id: str, player_name: str, job: str, chaos: int, rng: Optional[random.Random] = None) -> "Session":
+        return cast(Session, SessionBundle.new_session(session_id, player_name, job, chaos, rng))
+
+    @staticmethod
+    def load(session_id: str) -> Optional["Session"]:
+        return cast(Optional[Session], SessionBundle.redis_load(session_id))
+
+    def save(self, r: Optional[redis.Redis] = None) -> None:
+        self.redis_save(r)
+
+    @property
+    def char(self) -> Character:
+        return self.character
+
+    @property
+    def logs(self) -> List[str]:
+        return self.battle.logs
+
+
 # =========================
 # 便利関数（Flaskハンドラから使う想定）
 # =========================
@@ -525,7 +549,7 @@ def load_or_create_session(session_id: str, player_name: str = "名無し", job:
 def delete_session(session_id: str) -> bool:
     '''セッションを完全削除する（スライムLv1に戻す儀式）'''
     r = get_redis()
-    n = r.delete(rkey("session", session_id))
+    n = cast(int, r.delete(rkey("session", session_id)))
     return n > 0
 
 


### PR DESCRIPTION
## 概要
- Redis周りの型警告を修正
- 旧API互換の`Session`ラッパーを追加
- Graph/Appの型定義を整理

## テスト
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aefd831a408326a19751d7d38ee6ef